### PR TITLE
Fix for Python 3.9

### DIFF
--- a/default.py
+++ b/default.py
@@ -103,7 +103,7 @@ class MyePlayer(xbmc.Player):
             return
         if self._tracker is None:
             return
-        if self._tracker.isAlive():
+        if self._tracker.is_Alive():
             self._tracker.join()
         self._tracker = None
 


### PR DESCRIPTION
This is my first pull request. See https://bugs.python.org/issue37804 threading.isAlive is removed so is_Alive should apparently be used. I tested this on Debian 11 with Python 3.9.2 and running Kodi v19.4.